### PR TITLE
Small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 mercure.db
+/tests-server/*.js

--- a/packages/ld/ld.ts
+++ b/packages/ld/ld.ts
@@ -8,62 +8,71 @@ export type LdOptions<T extends object> = {
   onError: (err: unknown) => void;
 } & RequestInit;
 
-const table = new Map()
+type TableMap<T> = Map<string, T|undefined>;
 
-function proxyfy<T extends object>(obj: T, options: LdOptions<T>): T {
+const cachedTable: TableMap<unknown> = new Map()
+
+function proxify<T extends object>(obj: T, options: LdOptions<T>): T {
   if (undefined === options.root) {
-    table.clear()
+    cachedTable.clear()
     options.root = obj
   }
 
   return new Proxy<T>(obj, {
-    get: (target, prop, receiver) => {
-      const value = Reflect.get(target, prop, receiver);
+    get: (target: T, prop: string, receiver: unknown) => {
+      const value: string extends keyof T ? T[string] : unknown = Reflect.get(target, prop, receiver);
 
       if (typeof value === 'object' && value !== null) {
-        return proxyfy<any>(value, options);
+        return proxify<any>(value, options);
       }
 
       if (typeof value !== 'string') {
-        return value
+        return value;
       }
+
+      const valueStr = value.toString();
 
       // TODO: pattern matcher
       let absoluteValue = undefined
-      if (!options.urlPattern.test(value)) {
+      if (!options.urlPattern.test(valueStr)) {
         if (options.relativeURIs === false) {
-          return value;
+          return valueStr;
         }
 
-        if (value[0] !== '/') {
-          return value;
+        if (valueStr[0] !== '/') {
+          return valueStr;
         }
 
-        absoluteValue = `${options.urlPattern.protocol}://${options.urlPattern.hostname}${value}`;
+        absoluteValue = `${options.urlPattern.protocol}://${options.urlPattern.hostname}${valueStr}`;
         if (!options.urlPattern.test(absoluteValue)) {
-          return value;
+          return valueStr;
         }
       }
 
-      if (table.has(value)) {
-        return table.get(value);
+      if (cachedTable.has(valueStr)) {
+        return cachedTable.get(valueStr);
       }
 
-      table.set(value, undefined);
-      ; ((iri, object, t, uri) => {
-        (options as LdOptions<T>).fetchFn(uri)
-          .then(data => {
-            t.set(iri, data)
-            if (options.onUpdate) {
-              options.onUpdate(object, { iri, data })
-            }
-          })
-          .catch((err) => options.onError(err))
-      })(value, proxyfy((options as LdOptions<T>).root, options), table, absoluteValue === undefined ? value : absoluteValue)
-      return table.get(value)
+      cachedTable.set(valueStr, undefined);
+
+      const callFetch = (iri: string, object: T, tableMap: TableMap<T>, uri: RequestInfo | URL) => {
+        options.fetchFn(uri)
+            .then(data => {
+              tableMap.set(iri, data)
+              if (options.onUpdate) {
+                options.onUpdate(object, {iri, data})
+              }
+            })
+            .catch((err) => options.onError(err))
+      };
+
+      callFetch(valueStr, proxify(options.root, options), cachedTable as TableMap<T>, absoluteValue === undefined ? valueStr : absoluteValue)
+
+      return cachedTable.get(valueStr)
     }
   });
 }
+
 export default function ld<T extends object>(input: RequestInfo | URL, options: Partial<LdOptions<T>> = {}): Promise<T> {
   if (!options.urlPattern) {
     throw new Error('URL Pattern is mandatory.')
@@ -83,6 +92,6 @@ export default function ld<T extends object>(input: RequestInfo | URL, options: 
 
   return options.fetchFn(input, options)
     .then((d: T) => {
-      return proxyfy<T>(d, options as LdOptions<T>)
+      return proxify<T>(d, options as LdOptions<T>)
     })
 }

--- a/tests-server/index.html
+++ b/tests-server/index.html
@@ -25,22 +25,27 @@
     const list = document.getElementById('list')
 
     function onUpdate(books) {
-      const l = []
-      books['hydra:member'].forEach((book) => {
-        const li = document.createElement('li')
-        li.dataset.testid = 'book'
-        li.innerText = `${book.title} - ${book.author?.name}`
-        l.push(li)
+      books['hydra:member'].forEach((book, i) => {
+        // Emulate loading time with a random timeout
+        const delay = (i + 1) * Math.floor(Math.random() * (750 - 250) + 250);
+        setTimeout(() => {
+          const li = list.querySelector(`[data-bookid="${book['@id']}"]`);
+          if (!li) {
+            console.error(`Could not find list item with book id ${book['@id']}!`);
+            return;
+          }
+          li.innerText = `${book.title} - ${book.author?.name}`
+        }, delay);
       });
-      list.replaceChildren(...l)
     }
 
     ld('/books', {urlPattern: pattern, onUpdate})
       .then((books) => {
         books['hydra:member'].forEach((book) => {
           const li = document.createElement('li')
+          li.setAttribute('data-bookid', book['@id']);
           li.dataset.testid = 'book'
-          li.innerText = `${book.title} - ${book.author?.name}`
+          li.innerText = `${book.title} - ${book.author?.name || '(…)'}`
           list.appendChild(li)
         });
       })

--- a/tests/mercure.spec.ts
+++ b/tests/mercure.spec.ts
@@ -28,6 +28,7 @@ test('mercure', async ({ page }) => {
   await button.waitFor();
   expect(num).toBe(1);
   expect(requestedMercure).toBe(true);
+  // expect(subscribedToBoth).toBe(true); // TODO: check this part
   await expect(page.getByTestId('result')).toHaveText('viewing /authors/1: Dan Simmons');
   button.click({force: true});
   await expect(page.getByTestId('result')).toHaveText('viewing /authors/1: Soyuka');
@@ -36,4 +37,3 @@ test('mercure', async ({ page }) => {
   await page.waitForTimeout(600); // we set gcTime to 500, tanstack query will clear author 1 from cache, therefore we check that mercure gets updated
   expect(unsubscribedAuthor1).toBe(true);
 });
-


### PR DESCRIPTION
Some fixes:

* Enforce more types to be displayed in `ld.ts` 
* Ensure `value` is a scalar non-boolean and non-null stringable value before fetching new data
* Extract the fetching call to a `callFetch` function for more clarity (less clutter IMO)
* Add to gitignore the exported JS  files in `tests-server` 
* Rename `proxyfy` to `proxify` (more lexicographically correct, like "beauty/beautify" for example)
* Emulate loading time with a random timeout in default example in `tests-server/index.html`<br>Pretty neat as an example:<br> ![esa1](https://github.com/soyuka/esa/assets/3369266/d2056fd5-ef94-4027-b961-410bded3979b)<br>(now HTTP requests could use some kind of throttling too, I guess)<br>(and still not 100% sure this should be in the default example)
